### PR TITLE
Optimize message computations

### DIFF
--- a/bp_base/computators.py
+++ b/bp_base/computators.py
@@ -82,20 +82,12 @@ class BPComputator:
         try:
             # Stack all message data for vectorized operations
             msg_data = np.stack([msg.data for msg in messages])
+            total_sum = np.sum(msg_data, axis=0)
             outgoing_messages = []
 
-            # Vectorized computation: for each output message i, sum all except i
+            # Vectorized computation: subtract own message from total
             for i in range(n_messages):
-                # Create boolean mask to exclude message i
-                mask = np.ones(n_messages, dtype=bool)
-                mask[i] = False
-
-                # Sum remaining messages using vectorized operation
-                if np.any(mask):
-                    combined_data = np.sum(msg_data[mask], axis=0)
-                else:
-                    combined_data = np.zeros_like(messages[i].data)
-
+                combined_data = total_sum - msg_data[i]
                 outgoing_messages.append(
                     Message(
                         data=combined_data,
@@ -148,44 +140,47 @@ class BPComputator:
         cost_table_shape = cost_table.shape
         ndim = len(cost_table_shape)
 
+        # Precompute broadcasted messages for all variables
+        broadcasted_msgs = []
+        for msg in incoming_messages:
+            sender_dim = self._get_node_dimension(factor, msg.sender)
+            cache_key = (ndim, sender_dim, len(msg.data))
+            if cache_key not in self._broadcast_cache:
+                broadcast_shape = [1] * ndim
+                broadcast_shape[sender_dim] = len(msg.data)
+                self._broadcast_cache[cache_key] = tuple(broadcast_shape)
+            broadcast_shape = self._broadcast_cache[cache_key]
+            broadcasted_msgs.append(msg.data.reshape(broadcast_shape))
+
+        # Compute combined cost table once if using additive combine_func
+        aggregated_costs = cost_table.copy()
+        if self.combine_func == np.add:
+            for br_msg in broadcasted_msgs:
+                aggregated_costs = aggregated_costs + br_msg
+
         # Optimized computation for each message
         for i, msg_i in enumerate(incoming_messages):
             variable_node = msg_i.sender
 
             try:
                 dim = self._get_node_dimension(factor, variable_node)
-            except KeyError as e:
-                # Same error handling as original
+            except KeyError:
                 raise
 
-            # Optimized cost augmentation
-            augmented_costs = cost_table.copy()
+            if self.combine_func == np.add:
+                augmented_costs = aggregated_costs - broadcasted_msgs[i]
+            else:
+                augmented_costs = cost_table.copy()
+                for j, br_msg in enumerate(broadcasted_msgs):
+                    if j != i:
+                        augmented_costs = self.combine_func(augmented_costs, br_msg)
 
-            # Vectorized addition of messages from other variables
-            for j, msg_j in enumerate(incoming_messages):
-                if j != i:
-                    sender = msg_j.sender
-                    sender_dim = self._get_node_dimension(factor, sender)
-
-                    # Cached broadcast shape computation
-                    cache_key = (ndim, sender_dim, len(msg_j.data))
-                    if cache_key not in self._broadcast_cache:
-                        broadcast_shape = [1] * ndim
-                        broadcast_shape[sender_dim] = len(msg_j.data)
-                        self._broadcast_cache[cache_key] = tuple(broadcast_shape)
-
-                    broadcast_shape = self._broadcast_cache[cache_key]
-                    reshaped_msg = msg_j.data.reshape(broadcast_shape)
-                    augmented_costs = self.combine_func(augmented_costs, reshaped_msg)
-
-            # Marginalize over all dimensions except the recipient's
             axes_to_reduce = tuple(j for j in range(ndim) if j != dim)
             if axes_to_reduce:
                 reduced_msg = self.reduce_func(augmented_costs, axis=axes_to_reduce)
             else:
                 reduced_msg = augmented_costs
 
-            # Ensure proper shape
             if reduced_msg.ndim > 1:
                 reduced_msg = reduced_msg.ravel()
 

--- a/bp_base/factor_graph.py
+++ b/bp_base/factor_graph.py
@@ -74,8 +74,6 @@ class FactorGraph:
         Calculate the global cost of the factor graph at the current state.
         Based on current variable assignments and factor cost tables.
         """
-        # Get current assignments for all variables
-        var_assignments = {var: var.curr_assignment for var in self.variables}
         # Create a mapping from variable names to their assignments
         var_name_assignments = {var.name: var.curr_assignment for var in self.variables}
 


### PR DESCRIPTION
## Summary
- compute each variable-to-factor message by subtracting from the total sum
- precompute broadcasted factor messages and avoid cost table copies
- remove unused variable in `FactorGraph.global_cost`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68407f3487388324ad1c2426c89a95e0