### PR TITLE
Add factor graph creation tests

### DIFF
--- a/bp_base/__init__.py
+++ b/bp_base/__init__.py
@@ -1,10 +1,10 @@
 import logging
 import os
 
-log_level = os.environ.get('BP_LOG_LEVEL', 'CRITICAL').upper()
+log_level = os.environ.get("BP_LOG_LEVEL", "CRITICAL").upper()
 logging.getLogger().setLevel(getattr(logging, log_level, logging.CRITICAL))
 
-for module_name in ['bp_base', 'utils', 'policies']:
+for module_name in ["bp_base", "utils", "policies"]:
     logger = logging.getLogger(module_name)
     logger.setLevel(logging.CRITICAL)
     logger.propagate = False

--- a/bp_base/agents.py
+++ b/bp_base/agents.py
@@ -122,6 +122,7 @@ class FactorAgent(BPAgent):
     """
     Represents a factor node, storing a function that links multiple variables.
     """
+
     def __init__(
         self,
         name: str,

--- a/bp_base/computators.py
+++ b/bp_base/computators.py
@@ -28,14 +28,14 @@ class BPComputator:
         Same interface as original but with performance improvements.
         """
         # Use cached connection lookup if available
-        if hasattr(factor, '_connection_cache'):
-            return factor._connection_cache.get(node.name,
-                                                factor.connection_number.get(node.name, 0))
+        if hasattr(factor, "_connection_cache"):
+            return factor._connection_cache.get(
+                node.name, factor.connection_number.get(node.name, 0)
+            )
 
         # Original logic with caching
-        if not hasattr(factor, '_connection_cache'):
+        if not hasattr(factor, "_connection_cache"):
             factor._connection_cache = {}
-
 
         if node.name in factor.connection_number:
             factor._connection_cache[node.name] = factor.connection_number[node.name]
@@ -70,11 +70,13 @@ class BPComputator:
 
         # Fast path for single message
         if n_messages == 1:
-            return [Message(
-                data=np.zeros_like(messages[0].data),
-                sender=variable,
-                recipient=messages[0].sender
-            )]
+            return [
+                Message(
+                    data=np.zeros_like(messages[0].data),
+                    sender=variable,
+                    recipient=messages[0].sender,
+                )
+            ]
 
         # Vectorized computation when possible
         try:
@@ -94,11 +96,13 @@ class BPComputator:
                 else:
                     combined_data = np.zeros_like(messages[i].data)
 
-                outgoing_messages.append(Message(
-                    data=combined_data,
-                    sender=variable,
-                    recipient=messages[i].sender
-                ))
+                outgoing_messages.append(
+                    Message(
+                        data=combined_data,
+                        sender=variable,
+                        recipient=messages[i].sender,
+                    )
+                )
 
             return outgoing_messages
 
@@ -107,7 +111,9 @@ class BPComputator:
             outgoing_messages = []
             for i, msg_i in enumerate(messages):
                 factor = msg_i.sender
-                other_messages = [msg_j.data for j, msg_j in enumerate(messages) if j != i]
+                other_messages = [
+                    msg_j.data for j, msg_j in enumerate(messages) if j != i
+                ]
 
                 if other_messages:
                     combined_data = other_messages[0].copy()
@@ -116,9 +122,9 @@ class BPComputator:
                 else:
                     combined_data = np.zeros_like(msg_i.data)
 
-                outgoing_messages.append(Message(
-                    data=combined_data, sender=variable, recipient=factor
-                ))
+                outgoing_messages.append(
+                    Message(data=combined_data, sender=variable, recipient=factor)
+                )
 
             return outgoing_messages
 
@@ -183,9 +189,9 @@ class BPComputator:
             if reduced_msg.ndim > 1:
                 reduced_msg = reduced_msg.ravel()
 
-            outgoing_messages.append(Message(
-                data=reduced_msg, sender=factor, recipient=variable_node
-            ))
+            outgoing_messages.append(
+                Message(data=reduced_msg, sender=factor, recipient=variable_node)
+            )
 
         return outgoing_messages
 

--- a/tests/test_bp_base_basic.py
+++ b/tests/test_bp_base_basic.py
@@ -1,0 +1,37 @@
+import numpy as np
+from bp_base.components import Message, MailHandler
+from bp_base.agents import VariableAgent, FactorAgent
+from bp_base.computators import MinSumComputator
+
+
+def test_message_mailhandler_flow():
+    sender = VariableAgent("s", 2)
+    recipient = VariableAgent("r", 2)
+    msg = Message(np.array([1.0, 0.0]), sender, recipient)
+    sender.mailer.stage_sending([msg])
+    sender.mailer.send()
+    assert len(recipient.mailer.inbox) == 1
+    recipient.empty_mailbox()
+    assert len(recipient.mailer.inbox) == 0
+
+
+def test_min_sum_computator_q_r():
+    comp = MinSumComputator()
+    v = VariableAgent("v", 2)
+    f1 = FactorAgent("f1", 2, ct_creation_func=lambda n, d: np.zeros((d, d)), param={})
+    f2 = FactorAgent("f2", 2, ct_creation_func=lambda n, d: np.zeros((d, d)), param={})
+    m1 = Message(np.array([1.0, 2.0]), sender=f1, recipient=v)
+    m2 = Message(np.array([0.5, 1.5]), sender=f2, recipient=v)
+    q_msgs = comp.compute_Q([m1, m2])
+    assert len(q_msgs) == 2
+
+    f = FactorAgent("f", 2, ct_creation_func=lambda n, d: np.zeros((d, d)), param={})
+    f.cost_table = np.zeros((2, 2))
+    f.connection_number = {"v1": 0, "v2": 1}
+    v1 = VariableAgent("v1", 2)
+    v2 = VariableAgent("v2", 2)
+    r_msgs = comp.compute_R(f.cost_table, [
+        Message(np.array([0.0, 1.0]), sender=v1, recipient=f),
+        Message(np.array([1.0, 0.0]), sender=v2, recipient=f),
+    ])
+    assert len(r_msgs) == 2

--- a/tests/test_factor_graph_creation_methods.py
+++ b/tests/test_factor_graph_creation_methods.py
@@ -1,0 +1,60 @@
+import os
+import pickle
+import numpy as np
+import pytest
+
+from bp_base.agents import VariableAgent, FactorAgent
+from bp_base.factor_graph import FactorGraph
+from utils.examples import create_factor_graph
+from utils.create_factor_graphs_from_config import FactorGraphBuilder
+from utils.create_factor_graph_config import ConfigCreator
+from utils.path_utils import load_pickle
+
+
+def test_factor_graph_direct_creation():
+    v1 = VariableAgent(name="v1", domain=2)
+    v2 = VariableAgent(name="v2", domain=2)
+    ct_func = lambda n, d, **k: np.zeros((d, d))
+    f = FactorAgent(name="f12", domain=2, ct_creation_func=ct_func, param={})
+    fg = FactorGraph([v1, v2], [f], {f: [v1, v2]})
+
+    assert len(fg.variables) == 2
+    assert len(fg.factors) == 1
+    assert fg.G.has_edge(f, v1)
+    assert f.cost_table.shape == (2, 2)
+
+
+def test_create_factor_graph_cycle():
+    fg = create_factor_graph(graph_type="cycle", num_vars=3, domain_size=2)
+    assert len(fg.variables) == 3
+    assert len(fg.factors) == 3
+    # for a cycle of 3 variables there should be 6 edges (factor-variable)
+    assert len(fg.G.edges()) == 6
+
+
+def test_factor_graph_builder_cycle(tmp_path):
+    creator = ConfigCreator(base_dir=tmp_path)
+    cfg = creator.create_graph_config(
+        graph_type="cycle",
+        num_variables=3,
+        domain_size=2,
+        ct_factory="random_int",
+        ct_params={"low": 0, "high": 5},
+        density=1.0,
+    )
+    builder = FactorGraphBuilder(output_dir=tmp_path)
+    fg_path = builder.build_and_save(cfg)
+    assert os.path.exists(fg_path)
+    fg = builder.load_graph(fg_path)
+    assert isinstance(fg, FactorGraph)
+    assert len(fg.variables) == 3
+
+
+def test_factor_graph_pickle_load(tmp_path):
+    fg = create_factor_graph(graph_type="cycle", num_vars=3, domain_size=2)
+    pkl = tmp_path / "fg.pkl"
+    with open(pkl, "wb") as f:
+        pickle.dump(fg, f)
+    loaded = load_pickle(pkl)
+    assert isinstance(loaded, FactorGraph)
+    assert len(loaded.variables) == 3


### PR DESCRIPTION
## Summary
- add tests for creating factor graphs via different helpers
- add basic tests for mail handler and computator behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684004e254b88324851e6a7d264e2abe