### PR TITLE
Add optional numba JIT support for message computators

### DIFF
--- a/bp_base/bp_computators.py
+++ b/bp_base/bp_computators.py
@@ -1,9 +1,10 @@
 import numpy as np
-from typing import List
+from typing import List, Optional
 import logging
 
 try:
     import numba
+
     HAS_NUMBA = True
 except ImportError:
     HAS_NUMBA = False
@@ -16,22 +17,146 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.CRITICAL)
 
 
+def _compute_Q_numpy(msg_data: np.ndarray) -> np.ndarray:
+    """Compute Q messages using pure numpy operations."""
+    total_sum = np.sum(msg_data, axis=0)
+    result = np.empty_like(msg_data)
+    for i in range(msg_data.shape[0]):
+        result[i] = total_sum - msg_data[i]
+    return result
+
+
+def _compute_R_numpy(
+    cost_table: np.ndarray,
+    incoming: np.ndarray,
+    dims: np.ndarray,
+    reduce_type: int,
+    op_type: int,
+) -> np.ndarray:
+    """Compute R messages using numpy for environments without numba."""
+    n_messages = incoming.shape[0]
+    domain = incoming.shape[1]
+    ndim = cost_table.ndim
+    out = np.empty((n_messages, domain))
+    for i in range(n_messages):
+        augmented = cost_table.copy()
+        for j in range(n_messages):
+            if j != i:
+                broadcast_shape = [1] * ndim
+                broadcast_shape[dims[j]] = domain
+                reshaped = incoming[j].reshape(tuple(broadcast_shape))
+                if op_type == 0:
+                    augmented = augmented + reshaped
+                else:
+                    augmented = augmented * reshaped
+        axes = tuple(k for k in range(ndim) if k != dims[i])
+        if axes:
+            if reduce_type == 0:
+                reduced = augmented.min(axis=axes)
+            else:
+                reduced = augmented.max(axis=axes)
+        else:
+            reduced = augmented
+        if reduced.ndim > 1:
+            reduced = reduced.ravel()
+        out[i] = reduced
+    return out
+
+
+if HAS_NUMBA:
+    from numba import njit
+
+    @njit
+    def _compute_Q_jit(msg_data: np.ndarray) -> np.ndarray:
+        """JIT-compiled helper mirroring :func:`_compute_Q_numpy`."""
+        total_sum = np.sum(msg_data, axis=0)
+        out = np.empty_like(msg_data)
+        for i in range(msg_data.shape[0]):
+            out[i] = total_sum - msg_data[i]
+        return out
+
+    @njit
+    def _compute_R_jit(
+        cost_table: np.ndarray,
+        incoming: np.ndarray,
+        dims: np.ndarray,
+        reduce_type: int,
+        op_type: int,
+    ) -> np.ndarray:
+        """JIT-compiled helper mirroring :func:`_compute_R_numpy`."""
+        n_messages = incoming.shape[0]
+        domain = incoming.shape[1]
+        ndim = cost_table.ndim
+        out = np.empty((n_messages, domain))
+        for i in range(n_messages):
+            augmented = cost_table.copy()
+            for j in range(n_messages):
+                if j != i:
+                    broadcast_shape = [1] * ndim
+                    broadcast_shape[dims[j]] = domain
+                    reshaped = incoming[j].reshape(tuple(broadcast_shape))
+                    if op_type == 0:
+                        augmented = augmented + reshaped
+                    else:
+                        augmented = augmented * reshaped
+            axes_list = [k for k in range(ndim) if k != dims[i]]
+            if len(axes_list) > 0:
+                axes = tuple(axes_list)
+                if reduce_type == 0:
+                    reduced = augmented.min(axis=axes)
+                else:
+                    reduced = augmented.max(axis=axes)
+            else:
+                reduced = augmented
+            if reduced.ndim > 1:
+                reduced = reduced.ravel()
+            out[i] = reduced
+        return out
+
+else:
+    _compute_Q_jit = _compute_Q_numpy
+    _compute_R_jit = _compute_R_numpy
+
+
 class BPComputator:
     """
     Vectorized, cache-friendly version of the original BPComputator.
     """
 
-    def __init__(self, reduce_func, combine_func, parallel=False):
+    def __init__(self, reduce_func, combine_func, use_jit: bool = True):
         self.reduce_func = reduce_func
         self.combine_func = combine_func
+
         # Cache frequently used operations
         self._broadcast_cache = {}
-        # Initialize attributes used by optimized version
-        # but make them backward compatible
-        self._use_jit = False
-        self._parallel = False
-        self._operation_type = 0  # Default to addition
+
+        # Determine if JIT should be used
+        self._use_jit = bool(use_jit and HAS_NUMBA)
+
+        # Operation/reduction types used by jitted functions
+        if combine_func is np.add:
+            self._operation_type = 0
+        elif combine_func is np.multiply:
+            self._operation_type = 1
+        else:
+            self._operation_type = -1
+
+        if reduce_func is np.min:
+            self._reduce_type = 0
+        elif reduce_func is np.max:
+            self._reduce_type = 1
+        else:
+            self._reduce_type = -1
+
         self._current_factor = None
+
+        # Choose implementations based on JIT availability
+        if self._use_jit:
+            self._compute_Q_impl = _compute_Q_jit
+            self._compute_R_impl = _compute_R_jit
+        else:
+            self._compute_Q_impl = _compute_Q_numpy
+            self._compute_R_impl = _compute_R_numpy
 
     def _get_node_dimension(self, factor, node) -> int:
         """
@@ -68,18 +193,16 @@ class BPComputator:
             f"Available connections: {available_keys}"
         )
 
-    def compute_Q(self, messages: List[Message]) -> List[Message]:
-        """
-        Optimized Q message computation - same interface as original.
-        Uses vectorized operations for better performance.
-        """
+    def compute_Q(
+        self, messages: List[Message], use_jit: Optional[bool] = None
+    ) -> List[Message]:
+        """Compute Q messages with optional JIT acceleration."""
         if not messages:
             return []
 
         variable = messages[0].recipient
         n_messages = len(messages)
 
-        # Fast path for single message
         if n_messages == 1:
             return [
                 Message(
@@ -89,113 +212,59 @@ class BPComputator:
                 )
             ]
 
-        # Vectorized computation when possible
+        msg_data = np.stack([msg.data for msg in messages])
+
+        use_jit = self._use_jit if use_jit is None else bool(use_jit and HAS_NUMBA)
+
         try:
-            # Stack all message data for vectorized operations
-            msg_data = np.stack([msg.data for msg in messages])
-            total_sum = np.sum(msg_data, axis=0)
-            outgoing_messages = []
+            results = (self._compute_Q_impl if use_jit else _compute_Q_numpy)(msg_data)
+        except Exception:
+            results = _compute_Q_numpy(msg_data)
 
-            # Vectorized computation: subtract own message from total
-            for i in range(n_messages):
-                combined_data = total_sum - msg_data[i]
-                outgoing_messages.append(
-                    Message(
-                        data=combined_data,
-                        sender=variable,
-                        recipient=messages[i].sender,
-                    )
-                )
+        return [
+            Message(data=results[i], sender=variable, recipient=messages[i].sender)
+            for i in range(n_messages)
+        ]
 
-            return outgoing_messages
-
-        except (ValueError, TypeError):
-            # Fallback to original algorithm if vectorization fails
-            outgoing_messages = []
-            for i, msg_i in enumerate(messages):
-                factor = msg_i.sender
-                other_messages = [
-                    msg_j.data for j, msg_j in enumerate(messages) if j != i
-                ]
-
-                if other_messages:
-                    combined_data = other_messages[0].copy()
-                    for msg_data in other_messages[1:]:
-                        combined_data = self.combine_func(combined_data, msg_data)
-                else:
-                    combined_data = np.zeros_like(msg_i.data)
-
-                outgoing_messages.append(
-                    Message(data=combined_data, sender=variable, recipient=factor)
-                )
-
-            return outgoing_messages
-
-    def compute_R(self, cost_table, incoming_messages: List[Message]) -> List[Message]:
-        """
-        Optimized R message computation - same interface as original.
-        Uses caching and vectorized operations for better performance.
-        """
+    def compute_R(
+        self,
+        cost_table,
+        incoming_messages: List[Message],
+        use_jit: Optional[bool] = None,
+    ) -> List[Message]:
+        """Compute R messages with optional JIT acceleration."""
         if not incoming_messages:
             return []
 
         factor = incoming_messages[0].recipient
 
-        # Initialize connection cache if needed (same logic as original)
         if not hasattr(factor, "connection_number") or not factor.connection_number:
-            factor.connection_number = {}
-            for i, msg in enumerate(incoming_messages):
-                factor.connection_number[msg.sender.name] = i
+            factor.connection_number = {
+                msg.sender.name: i for i, msg in enumerate(incoming_messages)
+            }
 
-        outgoing_messages = []
-        cost_table_shape = cost_table.shape
-        ndim = len(cost_table_shape)
+        dims = np.array(
+            [self._get_node_dimension(factor, msg.sender) for msg in incoming_messages]
+        )
+        msg_data = np.stack([msg.data for msg in incoming_messages])
 
-        # Optimized computation for each message
-        for i, msg_i in enumerate(incoming_messages):
-            variable_node = msg_i.sender
+        use_jit = self._use_jit if use_jit is None else bool(use_jit and HAS_NUMBA)
 
-            try:
-                dim = self._get_node_dimension(factor, variable_node)
-            except KeyError as e:
-                # Same error handling as original
-                raise
-
-            # Optimized cost augmentation
-            augmented_costs = cost_table.copy()
-
-            # Vectorized addition of messages from other variables
-            for j, msg_j in enumerate(incoming_messages):
-                if j != i:
-                    sender = msg_j.sender
-                    sender_dim = self._get_node_dimension(factor, sender)
-
-                    # Cached broadcast shape computation
-                    cache_key = (ndim, sender_dim, len(msg_j.data))
-                    if cache_key not in self._broadcast_cache:
-                        broadcast_shape = [1] * ndim
-                        broadcast_shape[sender_dim] = len(msg_j.data)
-                        self._broadcast_cache[cache_key] = tuple(broadcast_shape)
-
-                    broadcast_shape = self._broadcast_cache[cache_key]
-                    reshaped_msg = msg_j.data.reshape(broadcast_shape)
-                    augmented_costs = self.combine_func(augmented_costs, reshaped_msg)
-
-            # Marginalize over all dimensions except the recipient's
-            axes_to_reduce = tuple(j for j in range(ndim) if j != dim)
-            if axes_to_reduce:
-                reduced_msg = self.reduce_func(augmented_costs, axis=axes_to_reduce)
-            else:
-                reduced_msg = augmented_costs
-
-            if reduced_msg.ndim > 1:
-                reduced_msg = reduced_msg.ravel()
-
-            outgoing_messages.append(
-                Message(data=reduced_msg, sender=factor, recipient=variable_node)
+        try:
+            results = (self._compute_R_impl if use_jit else _compute_R_numpy)(
+                cost_table, msg_data, dims, self._reduce_type, self._operation_type
+            )
+        except Exception:
+            results = _compute_R_numpy(
+                cost_table, msg_data, dims, self._reduce_type, self._operation_type
             )
 
-        return outgoing_messages
+        return [
+            Message(
+                data=results[i], sender=factor, recipient=incoming_messages[i].sender
+            )
+            for i in range(len(incoming_messages))
+        ]
 
 
 class MinSumComputator(BPComputator):
@@ -204,8 +273,8 @@ class MinSumComputator(BPComputator):
     Same interface as original but with performance improvements.
     """
 
-    def __init__(self):
-        super().__init__(reduce_func=np.min, combine_func=np.add)
+    def __init__(self, use_jit: bool = True):
+        super().__init__(reduce_func=np.min, combine_func=np.add, use_jit=use_jit)
 
 
 class MaxSumComputator(BPComputator):
@@ -214,5 +283,5 @@ class MaxSumComputator(BPComputator):
     Same interface as original but with performance improvements.
     """
 
-    def __init__(self):
-        super().__init__(reduce_func=np.max, combine_func=np.add)
+    def __init__(self, use_jit: bool = True):
+        super().__init__(reduce_func=np.max, combine_func=np.add, use_jit=use_jit)

--- a/tests/test_message_computing.py
+++ b/tests/test_message_computing.py
@@ -12,10 +12,12 @@ from base_all.agents import VariableAgent, FactorAgent
 def max_sum_computator():
     return MaxSumComputator()
 
+
 # Fixture for a MinSumComputator
 @pytest.fixture
 def min_sum_computator():
     return MinSumComputator()
+
 
 # Fixture for dummy agents
 @pytest.fixture
@@ -27,10 +29,12 @@ def dummy_sender():
 def dummy_recipient():
     return Agent(name="DummyRecipient", node_type="test")
 
+
 # Fixtures for variable and factor agents
 @pytest.fixture
 def variable_agent():
     return VariableAgent(name="x1", domain=3)
+
 
 @pytest.fixture
 def factor_agent():
@@ -44,6 +48,7 @@ def factor_agent():
     factor.connection_number = {"x1": 0, "x2": 1}
     return factor
 
+
 def create_test_cost_table(num_vars, domain_size, **kwargs):
     """Helper function to create a simple cost table for testing"""
     # Create a 3x3 cost table with predictable values
@@ -55,9 +60,7 @@ def test_compute_q_simple(max_sum_computator, variable_agent, factor_agent):
     """Test Q message computation with a simple case"""
     # Create test messages going into variable agent
     message1 = Message(
-        data=np.array([1.0, 2.0, 3.0]),
-        sender=factor_agent,
-        recipient=variable_agent
+        data=np.array([1.0, 2.0, 3.0]), sender=factor_agent, recipient=variable_agent
     )
 
     # Test with a single message
@@ -65,14 +68,16 @@ def test_compute_q_simple(max_sum_computator, variable_agent, factor_agent):
     assert len(result) == 1
     assert result[0].sender == variable_agent
     assert result[0].recipient == factor_agent
-    assert np.array_equal(result[0].data, np.zeros(3))  # Should be zeros for single message
+    np.testing.assert_array_equal(
+        result[0].data, np.zeros(3)
+    )  # Should be zeros for single message
 
     # Create another factor for testing with multiple messages
-    factor_agent2 = FactorAgent(name="f2", domain=3, ct_creation_func=create_test_cost_table)
+    factor_agent2 = FactorAgent(
+        name="f2", domain=3, ct_creation_func=create_test_cost_table
+    )
     message2 = Message(
-        data=np.array([4.0, 5.0, 6.0]),
-        sender=factor_agent2,
-        recipient=variable_agent
+        data=np.array([4.0, 5.0, 6.0]), sender=factor_agent2, recipient=variable_agent
     )
 
     # Test with multiple messages
@@ -80,28 +85,26 @@ def test_compute_q_simple(max_sum_computator, variable_agent, factor_agent):
     assert len(result) == 2
 
     # For first message, the outgoing message should be the data from message2
-    assert np.array_equal(result[0].data, np.array([4.0, 5.0, 6.0]))
+    np.testing.assert_array_equal(result[0].data, np.array([4.0, 5.0, 6.0]))
 
     # For second message, the outgoing message should be the data from message1
-    assert np.array_equal(result[1].data, np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(result[1].data, np.array([1.0, 2.0, 3.0]))
 
 
 # Test compute_Q method with the MinSumComputator
 def test_compute_q_min_sum(min_sum_computator, variable_agent, factor_agent):
     """Test Q message computation with MinSumComputator"""
     # Create test messages going into variable agent
-    factor_agent2 = FactorAgent(name="f2", domain=3, ct_creation_func=create_test_cost_table)
+    factor_agent2 = FactorAgent(
+        name="f2", domain=3, ct_creation_func=create_test_cost_table
+    )
 
     message1 = Message(
-        data=np.array([1.0, 2.0, 3.0]),
-        sender=factor_agent,
-        recipient=variable_agent
+        data=np.array([1.0, 2.0, 3.0]), sender=factor_agent, recipient=variable_agent
     )
 
     message2 = Message(
-        data=np.array([4.0, 5.0, 6.0]),
-        sender=factor_agent2,
-        recipient=variable_agent
+        data=np.array([4.0, 5.0, 6.0]), sender=factor_agent2, recipient=variable_agent
     )
 
     # Test with multiple messages
@@ -109,8 +112,8 @@ def test_compute_q_min_sum(min_sum_computator, variable_agent, factor_agent):
     assert len(result) == 2
 
     # Same behavior for min-sum as max-sum for Q messages
-    assert np.array_equal(result[0].data, np.array([4.0, 5.0, 6.0]))
-    assert np.array_equal(result[1].data, np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(result[0].data, np.array([4.0, 5.0, 6.0]))
+    np.testing.assert_array_equal(result[1].data, np.array([1.0, 2.0, 3.0]))
 
 
 # Test compute_R method with simple cost table
@@ -126,13 +129,13 @@ def test_compute_r_simple(max_sum_computator, variable_agent, factor_agent):
     message1 = Message(
         data=np.array([0.0, 0.0, 0.0]),  # Neutral values for addition
         sender=variable_agent,
-        recipient=factor_agent
+        recipient=factor_agent,
     )
 
     message2 = Message(
         data=np.array([0.0, 0.0, 0.0]),  # Neutral values for addition
         sender=variable_agent2,
-        recipient=factor_agent
+        recipient=factor_agent,
     )
 
     # Set up factor connections for compute_R
@@ -144,11 +147,11 @@ def test_compute_r_simple(max_sum_computator, variable_agent, factor_agent):
 
     # Check message to first variable (marginalize out dim 1)
     # For max-sum, this should be [3, 6, 9] (max of each row)
-    assert np.array_equal(result[0].data, np.array([3, 6, 9]))
+    np.testing.assert_array_equal(result[0].data, np.array([3, 6, 9]))
 
     # Check message to second variable (marginalize out dim 0)
     # For max-sum, this should be [7, 8, 9] (max of each column)
-    assert np.array_equal(result[1].data, np.array([7, 8, 9]))
+    np.testing.assert_array_equal(result[1].data, np.array([7, 8, 9]))
 
 
 # Test compute_R method with the MinSumComputator
@@ -164,13 +167,13 @@ def test_compute_r_min_sum(min_sum_computator, variable_agent, factor_agent):
     message1 = Message(
         data=np.array([0.0, 0.0, 0.0]),  # Neutral values for addition
         sender=variable_agent,
-        recipient=factor_agent
+        recipient=factor_agent,
     )
 
     message2 = Message(
         data=np.array([0.0, 0.0, 0.0]),  # Neutral values for addition
         sender=variable_agent2,
-        recipient=factor_agent
+        recipient=factor_agent,
     )
 
     # Set up factor connections for compute_R
@@ -182,15 +185,17 @@ def test_compute_r_min_sum(min_sum_computator, variable_agent, factor_agent):
 
     # Check message to first variable (marginalize out dim 1)
     # For min-sum, this should be [1, 4, 7] (min of each row)
-    assert np.array_equal(result[0].data, np.array([1, 4, 7]))
+    np.testing.assert_array_equal(result[0].data, np.array([1, 4, 7]))
 
     # Check message to second variable (marginalize out dim 0)
     # For min-sum, this should be [1, 2, 3] (min of each column)
-    assert np.array_equal(result[1].data, np.array([1, 2, 3]))
+    np.testing.assert_array_equal(result[1].data, np.array([1, 2, 3]))
 
 
 # Test compute_R with non-zero incoming messages
-def test_compute_r_with_incoming_values(max_sum_computator, variable_agent, factor_agent):
+def test_compute_r_with_incoming_values(
+    max_sum_computator, variable_agent, factor_agent
+):
     """Test R message computation with non-zero incoming messages"""
     # Set up a simple cost table for the factor
     cost_table = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -202,13 +207,13 @@ def test_compute_r_with_incoming_values(max_sum_computator, variable_agent, fact
     message1 = Message(
         data=np.array([1.0, 0.0, 2.0]),  # Will be added to cost table
         sender=variable_agent,
-        recipient=factor_agent
+        recipient=factor_agent,
     )
 
     message2 = Message(
         data=np.array([0.0, 1.0, 3.0]),  # Will be added to cost table
         sender=variable_agent2,
-        recipient=factor_agent
+        recipient=factor_agent,
     )
 
     # Set up factor connections
@@ -222,7 +227,7 @@ def test_compute_r_with_incoming_values(max_sum_computator, variable_agent, fact
     # For row 1: max([4+0, 5+1, 6+3]) = max([4, 6, 9]) = 9
     # For row 2: max([7+0, 8+1, 9+3]) = max([7, 9, 12]) = 12
     # Result: [6, 9, 12]
-    assert np.array_equal(result[0].data, np.array([6, 9, 12]))
+    np.testing.assert_array_equal(result[0].data, np.array([6, 9, 12]))
 
     # Expected computation for message to var2 (max over dim 0):
     # Due to the message computation logic in the current implementation,
@@ -231,22 +236,61 @@ def test_compute_r_with_incoming_values(max_sum_computator, variable_agent, fact
     # For col 1: max([2+1, 5+0, 8+2]) = max([3, 5, 10]) = 10
     # For col 2: max([3+1, 6+0, 9+2]) = max([4, 6, 11]) = 11
     # Result: [9, 10, 11]
-    assert np.array_equal(result[1].data, np.array([9, 10, 11]))
+    np.testing.assert_array_equal(result[1].data, np.array([9, 10, 11]))
 
 
 # Test JIT acceleration if available
 def test_jit_acceleration_flag():
     """Test that the JIT acceleration flag is properly set"""
-    # Create a computator with JIT flag set
-    computator = BPComputator(reduce_func=np.max, combine_func=np.add, parallel=True)
-
-    # Check that the JIT flag is set based on environment
     from bp_base.bp_computators import HAS_NUMBA
+
+    computator = BPComputator(reduce_func=np.max, combine_func=np.add, use_jit=True)
     assert computator._use_jit == HAS_NUMBA
+
+    computator_disabled = BPComputator(
+        reduce_func=np.max, combine_func=np.add, use_jit=False
+    )
+    assert not computator_disabled._use_jit
 
     # For common numpy functions, operation type should be recognized
     assert computator._operation_type == 0  # 0 for addition
 
     # Test with multiplication
-    computator2 = BPComputator(reduce_func=np.max, combine_func=np.multiply)
+    computator2 = BPComputator(
+        reduce_func=np.max, combine_func=np.multiply, use_jit=False
+    )
     assert computator2._operation_type == 1  # 1 for multiplication
+
+
+def test_jit_vs_numpy_paths(variable_agent, factor_agent):
+    """Ensure JIT and non-JIT implementations produce the same results."""
+    # Prepare messages
+    factor_agent2 = FactorAgent(
+        name="f2", domain=3, ct_creation_func=create_test_cost_table
+    )
+    msg1 = Message(
+        data=np.array([1.0, 2.0, 3.0]), sender=factor_agent, recipient=variable_agent
+    )
+    msg2 = Message(
+        data=np.array([4.0, 5.0, 6.0]), sender=factor_agent2, recipient=variable_agent
+    )
+
+    comp_jit = MaxSumComputator(use_jit=True)
+    comp_np = MaxSumComputator(use_jit=False)
+
+    res_jit = comp_jit.compute_Q([msg1, msg2])
+    res_np = comp_np.compute_Q([msg1, msg2])
+    for a, b in zip(res_jit, res_np):
+        np.testing.assert_array_equal(a.data, b.data)
+
+    # R-message comparison
+    cost_table = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    variable_agent2 = VariableAgent(name="x2", domain=3)
+    factor_agent.connection_number = {variable_agent.name: 0, variable_agent2.name: 1}
+    msg_r1 = Message(data=np.zeros(3), sender=variable_agent, recipient=factor_agent)
+    msg_r2 = Message(data=np.zeros(3), sender=variable_agent2, recipient=factor_agent)
+
+    res_jit_r = comp_jit.compute_R(cost_table, [msg_r1, msg_r2])
+    res_np_r = comp_np.compute_R(cost_table, [msg_r1, msg_r2])
+    for a, b in zip(res_jit_r, res_np_r):
+        np.testing.assert_array_equal(a.data, b.data)


### PR DESCRIPTION
## Summary
- add numba backed helper functions in `bp_base.bp_computators`
- use optional `use_jit` parameter to enable JIT versions of `compute_Q` and `compute_R`
- allow `MinSumComputator` and `MaxSumComputator` to pass through `use_jit`
- extend tests to cover JIT flag and equality between JIT and non-JIT paths
- replace `np.array_equal` with `np.testing.assert_array_equal`
- minor cleanup of computator class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6842df5f1f288324ba2d62ee259c59d9