### PR TITLE
Add tests for bp_base components and policies

### DIFF
--- a/tests/test_bp_base_additional.py
+++ b/tests/test_bp_base_additional.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pickle
+import os
+
+import pytest
+
+from bp_base.agents import VariableAgent, FactorAgent
+from bp_base.components import Message, MailHandler
+from bp_base.factor_graph import FactorGraph
+from bp_base.engine_components import Step, Cycle, History
+from bp_base.computators import MinSumComputator
+
+
+def create_simple_graph():
+    v1 = VariableAgent("v1", 2)
+    v2 = VariableAgent("v2", 2)
+    ct = np.array([[0, 1], [2, 3]])
+    f = FactorAgent("f", 2, ct_creation_func=lambda n, d: ct, param={})
+    edges = {f: [v1, v2]}
+    fg = FactorGraph(variable_li=[v1, v2], factor_li=[f], edges=edges)
+    return fg, v1, v2, f
+
+
+def test_factor_agent_properties():
+    fg, v1, v2, f = create_simple_graph()
+    # connection numbers should be set
+    assert f.connection_number == {"v1": 0, "v2": 1}
+    # cost table created by init
+    np.testing.assert_array_equal(f.cost_table, np.array([[0, 1], [2, 3]]))
+    # save original and modify
+    f.save_original()
+    f.cost_table = f.cost_table + 1
+    np.testing.assert_array_equal(f.original_cost_table, np.array([[0, 1], [2, 3]]))
+    # mean and total cost
+    assert f.mean_cost == pytest.approx(np.mean(f.cost_table))
+    assert f.total_cost == pytest.approx(np.sum(f.cost_table))
+
+
+def test_factor_graph_global_cost_and_pickle(tmp_path):
+    fg, v1, v2, f = create_simple_graph()
+    # assignments default to 0 so expected cost is cost_table[0,0]
+    assert fg.global_cost == 0
+
+    state = fg.__getstate__()
+    # simulate missing graph during unpickle
+    del state["G"]
+    new_fg = FactorGraph.__new__(FactorGraph)
+    new_fg.__setstate__(state)
+    assert new_fg.diameter == 2
+    assert new_fg.global_cost == 0
+
+    # pickle/unpickle roundtrip
+    pkl = tmp_path / "fg.pkl"
+    with open(pkl, "wb") as f_handle:
+        pickle.dump(fg, f_handle)
+    with open(pkl, "rb") as f_handle:
+        loaded = pickle.load(f_handle)
+    assert loaded.global_cost == fg.global_cost
+
+
+def test_mailhandler_deduplication():
+    sender = VariableAgent("s", 2)
+    recipient = VariableAgent("r", 2)
+    msg1 = Message(np.array([1, 0]), sender, recipient)
+    msg2 = Message(np.array([0, 1]), sender, recipient)
+    recipient.mailer.receive_messages(msg1)
+    # second message from same sender replaces first
+    recipient.mailer.receive_messages(msg2)
+    assert len(recipient.mailer.inbox) == 1
+    assert np.array_equal(recipient.mailer.inbox[0].data, [0, 1])
+    recipient.empty_mailbox()
+    assert len(recipient.mailer.inbox) == 0
+
+
+def test_variable_and_factor_compute_messages():
+    fg, v1, v2, f = create_simple_graph()
+    computator = MinSumComputator()
+    v1.computator = computator
+    f.computator = computator
+    # prepare messages from factor to variable
+    m = Message(np.array([1.0, 0.5]), sender=f, recipient=v1)
+    v1.mailer.receive_messages(m)
+    v1.compute_messages()
+    assert len(v1.mailer.outbox) == 1
+    # send to factor and compute R messages
+    v1.mailer.send()
+    f.mailer.receive_messages(v1.mailer.outbox[0])
+    f.compute_messages()
+    assert len(f.mailer.outbox) == 1
+
+
+def test_step_cycle_history(tmp_path):
+    sender = VariableAgent("s", 2)
+    recipient = VariableAgent("r", 2)
+    msg = Message(np.array([1, 2]), sender, recipient)
+    step = Step(0)
+    step.add(recipient, msg)
+
+    cycle = Cycle(0)
+    cycle.add(step)
+
+    hist = History(engine_type="Test")
+    hist[0] = cycle
+    hist.initialize_cost(1.0)
+    fn = hist.save_results(tmp_path / "results.json")
+    assert os.path.exists(fn)
+    loaded = pickle.load(open(fn, "rb"))
+    assert "beliefs" in loaded
+

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+
+from bp_base.agents import VariableAgent, FactorAgent
+from bp_base.components import Message
+from bp_base.factor_graph import FactorGraph
+
+from policies.damping import damp, TD
+from policies.cost_reduction import discount_attentive
+from policies.message_pruning import MessagePruningPolicy
+from policies.splitting import split_all_factors
+
+
+def setup_var_factor_graph():
+    v1 = VariableAgent("v1", 2)
+    v2 = VariableAgent("v2", 2)
+    ct = np.array([[1, 2], [3, 4]])
+    f = FactorAgent("f", 2, ct_creation_func=lambda n, d: ct, param={})
+    edges = {f: [v1, v2]}
+    fg = FactorGraph(variable_li=[v1, v2], factor_li=[f], edges=edges)
+    return fg, v1, v2, f
+
+
+def test_message_pruning_policy():
+    policy = MessagePruningPolicy(prune_threshold=0.1, min_iterations=0, adaptive_threshold=False)
+    v = VariableAgent("v", 2)
+    sender = FactorAgent("f", 2, ct_creation_func=lambda n,d: np.zeros((2,2)), param={})
+    msg1 = Message(np.array([0.0, 0.0]), sender, v)
+    msg2 = Message(np.array([0.05, 0.05]), sender, v)
+    assert policy.should_accept_message(v, msg1) is True
+    v.mailer.receive_messages(msg1)
+    assert policy.should_accept_message(v, msg2) is False
+    policy.step_completed()
+    stats = policy.get_stats()
+    assert stats["pruned_messages"] == 1
+    policy.reset()
+    assert policy.iteration_count == 0
+
+
+def test_damp_and_td():
+    fg, v1, v2, f = setup_var_factor_graph()
+    msg_prev = Message(np.array([1.0, 2.0]), sender=v1, recipient=f)
+    msg_curr = Message(np.array([3.0, 4.0]), sender=v1, recipient=f)
+    v1.mailer.outbox = [msg_curr]
+    v1._history.append([msg_prev])
+    damp(v1, 0.5)
+    np.testing.assert_array_almost_equal(msg_curr.data, 0.5 * msg_prev.data + 0.5 * np.array([3.0, 4.0]))
+
+    # TD on list of variables
+    msg_curr2 = Message(np.array([5.0, 6.0]), sender=v1, recipient=f)
+    v1.mailer.outbox = [msg_curr2]
+    v1._history.append([msg_curr])
+    TD([v1], 0.2, diameter=1)
+    np.testing.assert_array_almost_equal(msg_curr2.data, 0.2 * msg_curr.data + 0.8 * np.array([5.0,6.0]))
+
+
+def test_discount_attentive_and_split():
+    fg, v1, v2, f = setup_var_factor_graph()
+    # each variable receives a message to test weight
+    m1 = Message(np.array([1.0,1.0]), sender=f, recipient=v1)
+    m2 = Message(np.array([2.0,2.0]), sender=f, recipient=v2)
+    v1.mailer.receive_messages(m1)
+    v2.mailer.receive_messages(m2)
+    discount_attentive(fg)
+    # both variables degree=1 so weight=1
+    np.testing.assert_array_almost_equal(v1.mailer.inbox[0].data, np.array([1.0,1.0]))
+    np.testing.assert_array_almost_equal(v2.mailer.inbox[0].data, np.array([2.0,2.0]))
+    # check splitting keeps edges
+    orig_edges = list(fg.G.edges())
+    split_all_factors(fg, 0.5)
+    assert len(fg.factors) == 2
+    for _, var in orig_edges:
+        assert fg.G.degree(var) == 2


### PR DESCRIPTION
## Summary
- create additional unit tests covering FactorGraph, agents, mail handler and history
- add policy tests for damping, pruning and discounting

## Testing
- `pytest -q tests/test_bp_base_additional.py::test_factor_agent_properties` *(fails: ModuleNotFoundError)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement networkx~=3.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_684612af3ac0832499dbbc72e7b3a3cf